### PR TITLE
Allow "remove" hooks

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -132,13 +132,10 @@ module.exports = function MongooseRestRouter(base, router, options) {
             })
         }
 
-        if (M.findOneAndRemove)
-             M.findOneAndRemove(idObj(req), send);
-        else
-            M.findOne(idObj(req), function(err, doc){
-                if (err) return next(err);
-                doc.remove(send);
-            });
+        M.findOne(idObj(req), function(err, doc){
+            if (err) return next(err);
+            doc.remove(send);
+        });
 
     });
     function createstream(query, req, res, next) {


### PR DESCRIPTION
This works directly on the database and bypasses mongoose middleware pre/post hooks. Although it's faster, it's broken..

https://github.com/LearnBoost/mongoose/issues/964
https://github.com/LearnBoost/mongoose/issues/439
