### PR TITLE
A small documentation improvement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,11 +14,11 @@
     app.use('/rest', mers({uri:'mongodb://localhost/rest_example_prod'}).rest());
 ```
 Configuration options include:
-* uri://mongoose uri (as shown above)
-* mongoose:mongoose, (your mongoose instance)
-* [error][error]:function (your custom error handler)
-* responseStream:function (your custom respost stream. See: lib/streams.js)
-* transformer:function (your custom transformer factory)
+* `uri:uri://mongoose`  (as shown above)
+* `mongoose:mongoose` (your mongoose instance)
+* `[error][error]:function` (your custom error handler)
+* `responseStream:function` (your custom respost stream. See: lib/streams.js)
+* `transformer:function` (your custom transformer factory)
 
 
 ###If you had a schema such as


### PR DESCRIPTION
The list of parameters was mashed up into a paragraph before because Markdown was ignoring the linebreaks. This change makes it easier to read in GitHub's Markdown viewer.
