### PR TITLE
Update route.js to support "put" more than 2 levels deep

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -175,15 +175,22 @@ module.exports = function MongooseRestRouter(base, router, options) {
 
             if (pos) {
                 var o = obj
-                while (o && pos.length - 1) {
-                    o = o[pos.shift()]
+                var evalString = "obj";
+                while (o && pos.length > 0) {
+                    var shiftVar = pos.shift();
+                    if (o[shiftVar] instanceof Array) {
+                        evalString += "." + shiftVar
+                        o = o[shiftVar];
+                    } else {
+                        evalString += '.id("' + shiftVar +'")'
+                        o = _u.findWhere(o, {id: shiftVar});
+                    }
                 }
-                if (o[pos[0]] instanceof Array) {
-                    o[pos[0]].push(put);
+                if (eval(evalString) instanceof Array) {
+                    eval(evalString).push(put);
                 } else {
-                    o[pos[0]] = put;
+                    eval(evalString) = put;
                 }
-                obj.markModified(orig.join('.'));
 
             } else {
                 _u.extend(obj, put);


### PR DESCRIPTION
Modified routes.js to support deeper "levels" 
was having trouble with the code in router.put binding to an $id more than 2 levels deep

``` javascript

while (o && pos.length - 1) {
  o = o[pos.shift()]
}

```

Example:
Using the example from the readme, posting to

```
http://localhost:3000/rest/blogpost/$id/comments/ 
```

will work fine, however if you add another level like

```
http://localhost:3000/rest/blogpost/$id/comments/$id/notes/
```

then an error would occur.

I modified the code to assume that any additional layers would follow a path of

```
/level1/$id/level2/$id/level3/...etc
```
