### PR TITLE
Updated Mongoose in package.json peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,10 @@
     "body-parser": "~1.10.0",
     "should": "^5.1.0",
     "express": "^4.10.7",
-    "mongoose": "3.8.25",
     "supertest": "^0.15.0"
   },
   "peerDependencies": {
-    "mongoose": "^3.8.21"
+    "mongoose": "^4.0.0"
   },
   "scripts": {
     "test": "mocha test/*-mocha.js"


### PR DESCRIPTION
Package.json has the Mongoose version set to  `3.8.21` in  `peerDependencies` and `^4.0.0` in dependencies.  The peer dependencies was blocking me from installing `mongoose@4.0.5`
